### PR TITLE
Bump ndarray to 0.16.1

### DIFF
--- a/labview-interop/Cargo.toml
+++ b/labview-interop/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1"
 chrono = { version = "0.4", optional = true }
 dlopen2 = { version = "0.7", optional = true }
 dlopen2_derive = { version = "0.4", optional = true }
-ndarray = { version = "0.15", optional = true }
+ndarray = { version = "0.16.1", optional = true }
 ctor = { version = "0.2.4" }
 encoding_rs = "0.8"
 codepage = "0.1"

--- a/labview-test-library/Cargo.toml
+++ b/labview-test-library/Cargo.toml
@@ -6,8 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-labview-interop = {path = "../labview-interop", features = ["link", "ndarray"] }
-ndarray = "0.15"
+labview-interop = { path = "../labview-interop", features = [
+    "link",
+    "ndarray",
+] }
+ndarray = "0.16.1"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
bumped version of ndarray dependency. Tests ok.

Careful: ndarray 0.15 and 0.16 are incompatible, so all code depending on rust-interop and ndarray also need to bump versions.

Concerning semver this is probably a breaking change.