### PR TITLE
fix: Replace CTor with lazylock

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,14 @@
 ## v0.4.0
 
+### Breaking Changes
+
+* MSRV has been bumped to 1.80.0 for `LazyLock` support.
+
 ### Features
 
 * Added support for `LVStatusCode` and retrieving error descriptions from LabVIEW.
 * Added api for accessing dimensions of arrays.
+* Lazily load LabVIEW functions to allow time for LabVIEW to load.
 
 #### Fixes
 

--- a/labview-interop/Cargo.toml
+++ b/labview-interop/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/WiresmithTech/Rust-LabVIEW-Interop"
 description = "Types and wrappers for interperating with LabVIEW when called as a library"
 keywords = ["labview", "ni"]
 readme = "..\\README.md"
+rust-version = "1.80.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -18,7 +19,6 @@ chrono = { version = "0.4", optional = true }
 dlopen2 = { version = "0.7", optional = true }
 dlopen2_derive = { version = "0.4", optional = true }
 ndarray = { version = "0.16.1", optional = true }
-ctor = { version = "0.2.4" }
 encoding_rs = "0.8"
 codepage = "0.1"
 num_enum = "0.7.2"

--- a/labview-interop/src/errors.rs
+++ b/labview-interop/src/errors.rs
@@ -378,13 +378,13 @@ impl From<MgError> for LVStatusCode {
 ///
 /// Our choice of a custom ranges in Labview is (see comment above on valid ranges)
 /// 542,000 to 542,999
-#[derive(Error, Debug, Clone, Copy, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq)]
 #[repr(i32)]
 pub enum InternalError {
-    #[error("LabVIEW Interop General Error. Propably because of a missing implementation.")]
+    #[error("LabVIEW Interop General Error. Probably because of a missing implementation.")]
     Misc = 542_000,
-    #[error("LabVIEW API unavailable. Probably because it isn't being run in LabVIEW")]
-    NoLabviewApi = 542_001,
+    #[error("LabVIEW API unavailable. Probably because it isn't being run in LabVIEW. Source Error: {0}")]
+    NoLabviewApi(String) = 542_001,
     #[error("Invalid handle when valid handle is required")]
     InvalidHandle = 542_002,
     #[error("LabVIEW arrays can only have dimensions of i32 range.")]
@@ -401,11 +401,19 @@ pub enum InternalError {
 
 impl From<InternalError> for LVStatusCode {
     fn from(err: InternalError) -> LVStatusCode {
-        let err_i32: i32 = err as i32;
+        let err_i32: i32 = match err {
+            InternalError::Misc => 542_000,
+            InternalError::NoLabviewApi(_) => 542_001,
+            InternalError::InvalidHandle => 542_002,
+            InternalError::ArrayDimensionsOutOfRange => 542_003,
+            InternalError::ArrayDimensionMismatch => 542_004,
+            InternalError::HandleCreationFailed => 542_005,
+            InternalError::InvalidMgErrorCode => 542_006,
+        };
         err_i32.into()
     }
 }
-#[derive(Error, Debug, Clone, Copy, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq)]
 pub enum LVInteropError {
     #[error("Internal LabVIEW Manager Error: {0}")]
     LabviewMgError(#[from] MgError),
@@ -444,7 +452,8 @@ mod tests {
         let status: LVStatusCode = LVStatusCode::from(42);
         assert_eq!(status, err.into());
 
-        let err: LVInteropError = InternalError::NoLabviewApi.into();
+        let err: LVInteropError =
+            InternalError::NoLabviewApi("Test Inner message".to_string()).into();
         let status: LVStatusCode = LVStatusCode::from(542_001);
 
         println!("{}", status);

--- a/labview-interop/src/types/array/mod.rs
+++ b/labview-interop/src/types/array/mod.rs
@@ -9,11 +9,11 @@ mod ndarray;
 
 use crate::labview_layout;
 #[cfg(feature = "link")]
-pub use crate::memory::{OwnedUHandle };
-#[cfg(feature = "link")]
-pub use memory::NumericArrayResizable;
+pub use crate::memory::OwnedUHandle;
 use crate::memory::{LVCopy, UHandle};
 pub use dimensions::LVArrayDims;
+#[cfg(feature = "link")]
+pub use memory::NumericArrayResizable;
 
 labview_layout!(
     /// Internal LabVIEW array representation.

--- a/labview-interop/src/types/lv_errors.rs
+++ b/labview-interop/src/types/lv_errors.rs
@@ -33,6 +33,9 @@ labview_layout!(
 /// it can manipulate LabVIEW Strings.
 pub type ErrorClusterPtr<'a> = UPtr<ErrorCluster<'a>>;
 
+/// Format the source and description into a string that LabVIEW will interpret.
+// Only used in link but sat outside the module to make testing easier.
+#[cfg(any(test, feature = "link"))]
 fn format_error_source(source: &str, description: &str) -> String {
     match (source, description) {
         ("", description) => format!("<ERR>\n{description}"),

--- a/labview-interop/src/types/lv_errors.rs
+++ b/labview-interop/src/types/lv_errors.rs
@@ -33,7 +33,6 @@ labview_layout!(
 /// it can manipulate LabVIEW Strings.
 pub type ErrorClusterPtr<'a> = UPtr<ErrorCluster<'a>>;
 
-
 fn format_error_source(source: &str, description: &str) -> String {
     match (source, description) {
         ("", description) => format!("<ERR>\n{description}"),
@@ -49,7 +48,6 @@ mod error_cluster_link_features {
     use crate::types::boolean::{LV_FALSE, LV_TRUE};
 
     impl<'a> ErrorCluster<'a> {
-
         /// Set a description and source in the format that LabVIEW will interpret for display.
         fn set_source(&mut self, source: &str, description: &str) -> Result<()> {
             // Probably a clever way to avoid this allocation but for now we will take it.

--- a/labview-interop/src/types/string.rs
+++ b/labview-interop/src/types/string.rs
@@ -10,6 +10,7 @@ use crate::memory::OwnedUHandle;
 use crate::memory::{LVCopy, UHandle, UPtr};
 use encoding_rs::Encoding;
 use std::borrow::Cow;
+use std::sync::LazyLock;
 
 #[cfg(target_os = "windows")]
 fn get_encoding() -> &'static Encoding {
@@ -37,9 +38,8 @@ fn get_encoding() -> &'static Encoding {
     encoding_rs::UTF_8
 }
 
-#[ctor::ctor]
 /// The encoding that LabVIEW uses on the current platform.
-pub(crate) static LV_ENCODING: &'static Encoding = get_encoding();
+pub(crate) static LV_ENCODING: LazyLock<&'static Encoding> = LazyLock::new(get_encoding);
 
 labview_layout!(
     /// Internal LabVIEW string structure.


### PR DESCRIPTION
* Seen possible race condition with CTor initialising before the LabVIEW RTE.
* Replaced with new std library LazyLock so it is lazily evaluated which should mean the RTE is initialised before we run.

Refs: #40