### PR TITLE
chore: Make test library publish: false

### DIFF
--- a/labview-test-library/Cargo.toml
+++ b/labview-test-library/Cargo.toml
@@ -2,6 +2,7 @@
 name = "labview-test-library"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
We had an error when setting up release-plz because it was still trying to publish the test-library. This should fix that by setting publish to false.