### PR TITLE
chore(release): Link the readme at the repo level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 members = ["labview-interop", "labview-test-library"]
 resolver = "2"
+
+[workspace.package]
+readme = "README.md"
+repository = "https://github.com/WiresmithTech/Rust-LabVIEW-Interop"
+homepage = "https://github.com/WiresmithTech/Rust-LabVIEW-Interop"
+edition = "2021"

--- a/labview-interop/Cargo.toml
+++ b/labview-interop/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "labview-interop"
 version = "0.4.0"
-edition = "2021"
+edition = { workspace = true }
 license = "MIT"
-homepage = "https://github.com/WiresmithTech/Rust-LabVIEW-Interop"
-repository = "https://github.com/WiresmithTech/Rust-LabVIEW-Interop"
+homepage = { workspace = true }
+repository = { workspace = true }
 description = "Types and wrappers for interperating with LabVIEW when called as a library"
 keywords = ["labview", "ni"]
-readme = "..\\README.md"
+readme = { workspace = true}
 rust-version = "1.80.0"
 
 


### PR DESCRIPTION
Release-plz was throwing errors due to failing to link up to the file. (and other tools complained too)