### PR TITLE
Bump dependency versions

### DIFF
--- a/labview-interop/Cargo.toml
+++ b/labview-interop/Cargo.toml
@@ -16,9 +16,9 @@ rust-version = "1.80.0"
 [dependencies]
 thiserror = "2"
 chrono = { version = "0.4", optional = true }
-dlopen2 = { version = "0.7", optional = true }
+dlopen2 = { version = "0.8", optional = true }
 dlopen2_derive = { version = "0.4", optional = true }
-ndarray = { version = "0.16.1", optional = true }
+ndarray = { version = "0.17", optional = true }
 encoding_rs = "0.8"
 codepage = "0.1"
 num_enum = "0.7.2"

--- a/labview-test-library/Cargo.toml
+++ b/labview-test-library/Cargo.toml
@@ -11,7 +11,7 @@ labview-interop = { path = "../labview-interop", features = [
     "link",
     "ndarray",
 ] }
-ndarray = "0.16.1"
+ndarray = "0.17"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Update
- dlopen2 to 0.8
- ndarray to 0.17

Compiles, locally tests run.